### PR TITLE
Pre commit checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+[flake8]
+max-line-length = 120
+ignore = E266, BLK100
+# flake8 does not parse the .gitignore file so we need to re-specify what to ignore
+exclude =
+    .git,
+    .idea,
+    __pycache__.
+    .DS_Store,
+    .hypothesis,
+    .pytest_cache,
+    *.egg-info,
+    .eggs,
+    venv,
+    venv2,
+    build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+    - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+    - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Web app for node manager
 # Requirements
 
 FastAPI - [https://fastapi.tiangolo.com/](https://fastapi.tiangolo.com/)
+
+# Development
+
+## Style Checking
+
+Coding style is enforced using the [pre-commit](https://pre-commit.com/) package.
+
+You can set up your local git repository so that these style checks are automatically triggered whenever you
+make a new commit.
+
+```shell
+pip install pre-commit  # Install the pre-commit package
+pre-commit install      # Install the pre-commit hooks defined in .pre-commit-config.yaml to the .git/ directory for this repo
+```
+
+Now whenever you make a commit, the style checks will run automatically and suggest changes to your code!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+extend-exclude = '\.git'


### PR DESCRIPTION
Adds coding style is enforced using the [pre-commit](https://pre-commit.com/) package.

Developers can now set up your local git repository so that these style checks are automatically triggered whenever you
make a new commit.

```shell
pip install pre-commit  # Install the pre-commit package
pre-commit install      # Install the pre-commit hooks defined in .pre-commit-config.yaml to the .git/ directory for this repo
```

Now whenever you make a commit, the style checks will run automatically and suggest changes to your code!